### PR TITLE
Implement starred and feed endpoints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/feedbin_tools/cli.py
+++ b/feedbin_tools/cli.py
@@ -3,6 +3,8 @@ import logging
 import sys
 from itertools import islice
 from pprint import pformat
+from datetime import datetime, timezone
+
 
 import click
 
@@ -201,6 +203,10 @@ def starred(ctx, chunk_size, extended, ids, limit):
                     logging.info("Reached limit of %d, completed", limit)
                     return
 
+                current_utc = datetime.now(timezone.utc)
+                iso_format = current_utc.isoformat()
+                item["x-retrieved-at"] = iso_format
+
                 sys.stdout.write(json.dumps(item) + "\n")
                 total_emitted += 1
 
@@ -228,6 +234,11 @@ def feed(ctx, feed_id, extended, limit):
         if 0 <= limit <= total_emitted:
             logging.info("Reached limit of %d, completed", limit)
             return
+
+        current_utc = datetime.now(timezone.utc)
+        iso_format = current_utc.isoformat()
+
+        item["x-retrieved-at"] = iso_format
 
         sys.stdout.write(json.dumps(item) + "\n")
         total_emitted += 1

--- a/feedbin_tools/cli.py
+++ b/feedbin_tools/cli.py
@@ -4,10 +4,28 @@ import sys
 
 import click
 
+from itertools import zip_longest
+
 from .logconfig import DEFAULT_LOG_FORMAT, logging_config
 
 import requests
 import requests_cache
+
+
+def grouper(iterable, n, *, incomplete="fill", fillvalue=None):
+    "Collect data into non-overlapping fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, fillvalue='x') --> ABC DEF Gxx
+    # grouper('ABCDEFG', 3, incomplete='strict') --> ABC DEF ValueError
+    # grouper('ABCDEFG', 3, incomplete='ignore') --> ABC DEF
+    args = [iter(iterable)] * n
+    if incomplete == "fill":
+        return zip_longest(*args, fillvalue=fillvalue)
+    if incomplete == "strict":
+        return zip(*args, strict=True)
+    if incomplete == "ignore":
+        return zip(*args)
+    else:
+        raise ValueError("Expected fill, strict, or ignore")
 
 
 @click.group()
@@ -34,13 +52,35 @@ def cli(log_format, log_level, log_file):
 
 
 @cli.command(name="subscriptions")
-def first_command():
+def subscriptions():
     "Command description goes here"
 
     logging.info("Here's some log output")
 
-    session = requests_cache.CachedSession()
+    session = requests_cache.CachedSession("memory_cache", backend="memory")
     resp = session.get("https://api.feedbin.com/v2/subscriptions.json")
     resp.raise_for_status()
 
     json.dump(resp.json(), sys.stdout)
+
+
+@cli.command(name="starred")
+def starred():
+    "Command description goes here"
+
+    CHUNK_SIZE = 75
+    session = requests_cache.CachedSession("memory_cache", backend="memory")
+    resp = session.get("https://api.feedbin.com/v2/starred_entries.json")
+
+    resp.raise_for_status()
+
+    starred_ids = resp.json()
+
+    logging.info("Starred entries id count: %d", len(starred_ids))
+
+    for i, chunk in enumerate(
+        grouper(starred_ids, CHUNK_SIZE, incomplete="fill", fillvalue=None), 1
+    ):
+        clean_chunk = [v for v in chunk if v]
+
+    logging.info("Processed %d chunks of size %d or less", i, CHUNK_SIZE)


### PR DESCRIPTION
Implement cli subcommands to retrieve entries from the `starred` and `feed` endpoints of the feedbin API. The starred subcommand can also return the entry ids instead of the entry JSON.

Implemented adhering to pagination from the feedbin api spec.

Bumped the GitHub actions pipelines to start with Python version 3.8. This PR introduces usage of the walrus operator which is only available in 3.8+.